### PR TITLE
build(config): implement dynamic port mapping with spring-dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Environment variable ###
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
     ports:
-      - "${DB_PORT}:5432"
+      - "${DB_PORT:-5432}:5432"
     volumes:
       - pg_data:/var/lib/postgresql/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+
 
 services:
   postgres:
@@ -10,7 +10,7 @@ services:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
     ports:
-      - "5432:5432"
+      - "${DB_PORT}:5432"
     volumes:
       - pg_data:/var/lib/postgresql/data
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>me.paulschwarz</groupId>
+            <artifactId>spring-dotenv</artifactId>
+            <version>4.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator-test</artifactId>
             <scope>test</scope>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=quote-remittance-backend
 
-spring.datasource.url=jdbc:postgresql://localhost:5432/remittance
+spring.datasource.url=jdbc:postgresql://localhost:${DB_PORT}/remittance
 spring.datasource.username=admin
 spring.datasource.password=admin123
 spring.datasource.driver-class-name=org.postgresql.Driver

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=quote-remittance-backend
 
-spring.datasource.url=jdbc:postgresql://localhost:${DB_PORT}/remittance
+spring.datasource.url=jdbc:postgresql://localhost:${DB_PORT:5432}/remittance
 spring.datasource.username=admin
 spring.datasource.password=admin123
 spring.datasource.driver-class-name=org.postgresql.Driver


### PR DESCRIPTION
- Added  dependency to  for native  parsing.
- Updated  and  to use
- Added  to  to secure local environment variables.

This ensures local port collisions can be safely bypassed via a local  file without breaking the default database configuration for the rest of the team.