### PR TITLE
Feature/19 implement payout entity

### DIFF
--- a/src/main/java/com/remittance/payout/entity/Payout.java
+++ b/src/main/java/com/remittance/payout/entity/Payout.java
@@ -12,6 +12,9 @@ import java.util.UUID;
 @Getter
 @Entity
 @NoArgsConstructor
+@Getter
+@NoArgsConstructor
+@Entity
 public class Payout {
 
     @Id

--- a/src/main/java/com/remittance/payout/entity/Payout.java
+++ b/src/main/java/com/remittance/payout/entity/Payout.java
@@ -2,6 +2,8 @@ package com.remittance.payout.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;

--- a/src/main/java/com/remittance/payout/entity/Payout.java
+++ b/src/main/java/com/remittance/payout/entity/Payout.java
@@ -1,4 +1,41 @@
 package com.remittance.payout.entity;
 
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
 public class Payout {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false)
+    private UUID id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "remittance_id", nullable = false, unique = true )
+    private Remittance remittance;
+
+    @Column(nullable = false, unique = true)
+    private String providerReference;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+
+    public enum Status {
+        PENDING,
+        SUCCESS,
+        FAILED
+    }
+
 }

--- a/src/main/java/com/remittance/payout/entity/Payout.java
+++ b/src/main/java/com/remittance/payout/entity/Payout.java
@@ -1,12 +1,17 @@
 package com.remittance.payout.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+@Getter
+@Entity
+@NoArgsConstructor
 public class Payout {
 
     @Id

--- a/src/main/java/com/remittance/payout/entity/Payout.java
+++ b/src/main/java/com/remittance/payout/entity/Payout.java
@@ -1,0 +1,4 @@
+package com.remittance.payout.entity;
+
+public class Payout {
+}

--- a/src/main/java/com/remittance/quote/entity/Quote.java
+++ b/src/main/java/com/remittance/quote/entity/Quote.java
@@ -17,6 +17,9 @@ public class Quote {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
+    @Column(nullable = false, unique = true)
+    private String quoteReference;
+
     @ManyToOne(fetch = FetchType.LAZY )
     @JoinColumn(name = "user_id", nullable = false)
     private User user;

--- a/src/main/java/com/remittance/quote/entity/Quote.java
+++ b/src/main/java/com/remittance/quote/entity/Quote.java
@@ -3,7 +3,6 @@ package com.remittance.quote.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.math.BigDecimal;
@@ -18,23 +17,22 @@ public class Quote {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY )
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Setter
     @Column(precision = 18, scale = 2)
     private BigDecimal sendAmount;
 
     @Enumerated(EnumType.STRING)
-    @Setter
+    @Column(nullable = false)
     private Currency fromCurrency;
 
     @Enumerated(EnumType.STRING)
-    @Setter
+    @Column(nullable = false)
     private Currency toCurrency;
 
-    @Column(precision = 18, scale = 6)
+    @Column( nullable = false, precision = 18, scale = 6)
     private BigDecimal exchangeRate;
 
     @Column(precision = 18, scale = 2)
@@ -47,13 +45,13 @@ public class Quote {
     private BigDecimal totalPayable;
 
     @Enumerated(EnumType.STRING)
-    @Setter
+    @Column(nullable = false)
     private Status status ;
 
     @CreationTimestamp
     private LocalDateTime createdAt;
 
-    @Setter
+    @Column(nullable = false)
     private LocalDateTime expiresAt;
 
 

--- a/src/main/java/com/remittance/quote/entity/Quote.java
+++ b/src/main/java/com/remittance/quote/entity/Quote.java
@@ -1,0 +1,67 @@
+package com.remittance.quote.entity;
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+public class Quote {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(precision = 18, scale = 2)
+    private BigDecimal sendAmount;
+
+    @Enumerated(EnumType.STRING)
+    private Currency fromCurrency;
+
+    @Enumerated(EnumType.STRING)
+    private Currency toCurrency;
+
+    @Column(precision = 18, scale = 6)
+    private BigDecimal exchangeRate;
+
+    @Column(precision = 18, scale = 2)
+    private BigDecimal fee;
+
+    @Column(precision = 18, scale = 2)
+    private BigDecimal recieveAmount;
+
+    @Column(precision = 18, scale = 2)
+    private BigDecimal totalPayable;
+
+    @Enumerated(EnumType.STRING)
+    private Status status ;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime expiresAt;
+
+
+
+
+
+
+
+
+
+    public enum Currency {
+        USD,
+        EUR,
+        GBP,
+        NGN
+    }
+
+    public enum Status{
+        ACTIVE,
+        USED,
+        EXPIRED
+    }
+}

--- a/src/main/java/com/remittance/quote/entity/Quote.java
+++ b/src/main/java/com/remittance/quote/entity/Quote.java
@@ -1,11 +1,17 @@
 package com.remittance.quote.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+@Getter
+@NoArgsConstructor
 @Entity
 public class Quote {
     @Id
@@ -16,13 +22,16 @@ public class Quote {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Setter
     @Column(precision = 18, scale = 2)
     private BigDecimal sendAmount;
 
     @Enumerated(EnumType.STRING)
+    @Setter
     private Currency fromCurrency;
 
     @Enumerated(EnumType.STRING)
+    @Setter
     private Currency toCurrency;
 
     @Column(precision = 18, scale = 6)
@@ -32,24 +41,20 @@ public class Quote {
     private BigDecimal fee;
 
     @Column(precision = 18, scale = 2)
-    private BigDecimal recieveAmount;
+    private BigDecimal receiveAmount;
 
     @Column(precision = 18, scale = 2)
     private BigDecimal totalPayable;
 
     @Enumerated(EnumType.STRING)
+    @Setter
     private Status status ;
 
+    @CreationTimestamp
     private LocalDateTime createdAt;
 
+    @Setter
     private LocalDateTime expiresAt;
-
-
-
-
-
-
-
 
 
     public enum Currency {


### PR DESCRIPTION
## What was done
- Created Payout entity
- Established one-to-one relationship with Remittance
- Added providerReference for external payout tracking
- Implemented Status enum (PENDING, SUCCESS, FAILED)
- Added timestamps for tracking payout lifecycle

## Why
To handle the payout stage of the remittance flow and track the transfer of funds to the recipient.

## Notes
- One payout is strictly linked to one remittance (1:1 mapping)
- providerReference is unique and used for external provider tracking
- Status field controls payout lifecycle